### PR TITLE
add sync algebra to poll api data and upsert it to redis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -383,6 +383,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tokio-scoped",
 ]
 
 [[package]]
@@ -1216,6 +1217,16 @@ checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
  "tokio",
+]
+
+[[package]]
+name = "tokio-scoped"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4beb8ba13bc53ac53ce1d52b42f02e5d8060f0f42138862869beb769722b256"
+dependencies = [
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,4 @@ log = "0.4.21"
 serde = { version = "1.0.199", features = ["derive"] }
 serde_json = "1.0.116"
 tokio = { version = "1.37.0", features = ["full"] }
+tokio-scoped = "0.2.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,24 +6,9 @@ use crate::algebras::event_sync::EventSync;
 use crate::algebras::event_sync::EventSyncImpl;
 use crate::algebras::http_requester::TelemetryHttpRequester;
 use crate::algebras::redis::RedisImpl;
-use crate::types::car_data::CarData;
-use crate::types::car_location::CarLocation;
 use crate::types::driver::*;
-use crate::types::flag::*;
-use crate::types::interval::Interval;
-use crate::types::lap::Lap;
-use crate::types::meeting::Meeting;
-use crate::types::pit::Pit;
-use crate::types::position::Position;
-use crate::types::race_controls::*;
+use crate::types::event_sync::EventSyncConfig;
 use crate::types::session::Session;
-use crate::types::stint::Stint;
-use crate::types::team_radio::TeamRadio;
-use crate::types::weather::Weather;
-use fred::prelude::*;
-use fred::types::RedisConfig;
-use fred::types::*;
-use log::info;
 use std::error::Error;
 
 #[tokio::main]
@@ -38,9 +23,19 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let redis_client: RedisImpl = RedisImpl::default().expect("unable to connect to redis");
 
+    let event_sync_delay_config = EventSyncConfig {
+        car_data_duration_secs: 2,
+        interval_duration_secs: 5,
+        team_radio_duration_secs: 30,
+        laps_duration_secs: 120,
+        pit_duration_secs: 120,
+        position_duration_secs: 5, //TODO: probably higher if we're not using this...
+        stints_duration_secs: 120,
+    };
     let event_sync = EventSyncImpl {
         api: &api,
         redis: &redis_client,
+        delay_config: &event_sync_delay_config,
     };
 
     let sessions: Option<Vec<Session>> =

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,11 +54,13 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // let _ = event_sync
     //     .car_data_sync(session.session_key, Some(driver_number), Some(50))
     //     .await;
-    //    info!("car data: {}", car_data);
-    // let _ = event_sync.intervals_sync(session.session_key, None).await;
-    let _ = event_sync
-        .team_radio_sync(session.session_key, Some(driver_number))
-        .await;
+    //let _ = event_sync.intervals_sync(session.session_key, None).await;
+    // let _ = event_sync
+    //     .team_radio_sync(session.session_key, Some(driver_number))
+    //     .await;
+    // let _ = event_sync
+    //     .laps_sync(session.session_key, &driver_number, 1)
+    //     .await;
     Ok(())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,9 +62,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
     //     .laps_sync(session.session_key, &driver_number, 1)
     //     .await;
     // let _ = event_sync.pit_sync(session.session_key, None).await;
-    let _ = event_sync
-        .position_sync(session.meeting_key, &driver_number, None)
-        .await;
+    // let _ = event_sync
+    //     .position_sync(session.meeting_key, &driver_number, None)
+    //     .await;
+    let _ = event_sync.stints_sync(session.session_key, None).await;
     Ok(())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,10 +51,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .expect("Session not found, or request timed out");
 
     let driver_number = get_driver_number(&DriverName::LandoNorris);
-    let _ = event_sync
-        .car_data_sync(session.session_key, Some(driver_number), Some(50))
-        .await;
+    // let _ = event_sync
+    //     .car_data_sync(session.session_key, Some(driver_number), Some(50))
+    //     .await;
     //    info!("car data: {}", car_data);
+    let _ = event_sync.intervals_sync(session.session_key, None).await;
     Ok(())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,7 +61,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // let _ = event_sync
     //     .laps_sync(session.session_key, &driver_number, 1)
     //     .await;
-    let _ = event_sync.pit_sync(session.session_key, None).await;
+    // let _ = event_sync.pit_sync(session.session_key, None).await;
+    let _ = event_sync
+        .position_sync(session.meeting_key, &driver_number, None)
+        .await;
     Ok(())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,7 +55,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
     //     .car_data_sync(session.session_key, Some(driver_number), Some(50))
     //     .await;
     //    info!("car data: {}", car_data);
-    let _ = event_sync.intervals_sync(session.session_key, None).await;
+    // let _ = event_sync.intervals_sync(session.session_key, None).await;
+    let _ = event_sync
+        .team_radio_sync(session.session_key, Some(driver_number))
+        .await;
     Ok(())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,69 +65,20 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // let _ = event_sync
     //     .position_sync(session.meeting_key, &driver_number, None)
     //     .await;
-    let _ = event_sync.stints_sync(session.session_key, None).await;
+    //let _ = event_sync.stints_sync(session.session_key, None).await;
+    let _ = event_sync
+        .run_sync(
+            session.session_key,
+            session.meeting_key,
+            None,
+            None,
+            driver_number,
+            60,
+            None,
+            None,
+            None,
+        )
+        .await;
+
     Ok(())
-}
-
-fn test_requests() {
-    let http_requester = TelemetryHttpRequester;
-    let api = CarDataApiImpl {
-        http_requester: &http_requester,
-        uri: "https://api.openf1.org",
-    };
-
-    let sessions: Option<Vec<Session>> =
-        api.get_session(&"Belgium".to_string(), &"Sprint".to_string(), 2023);
-    println!("Sessions: {:?}", sessions);
-
-    let driver_number = get_driver_number(&DriverName::MaxVerstappen);
-    let session: Session = sessions.unwrap().pop().unwrap();
-    let drivers: Option<Vec<Driver>> = api.get_drivers(session.session_key, &driver_number);
-    println!("Drivers: {:?}", drivers);
-
-    let car_data: Option<Vec<CarData>> =
-        api.get_car_data(session.session_key, Some(driver_number), Some(315));
-    //println!("CarData: {:?}", car_data);
-
-    let interv: Option<f32> = Some(0.01f32);
-    let interval: Option<Vec<Interval>> = api.get_intervals(session.session_key, interv);
-    println!("Interval: {:?}", interval);
-
-    let laps: Option<Vec<Lap>> = api.get_lap(session.session_key, &driver_number, 8);
-    println!("Laps: {:?}", laps);
-
-    let car_loc_driver = get_driver_number(&DriverName::OscarPiastri);
-    let car_locations: Option<Vec<CarLocation>> = api.get_car_location(
-        9161,
-        &car_loc_driver,
-        &"2023-09-16T13:03:35.200",
-        &"2023-09-16T13:03:35.800",
-    );
-    println!("CarLocations: {:?}", car_locations);
-
-    let meeting: Option<Vec<Meeting>> = api.get_meeting(2023, &"Singapore");
-    println!("Meeting: {:?}", meeting);
-
-    let pit: Option<Vec<Pit>> = api.get_pit(9158, Some(25));
-    println!("Pit: {:?}", pit);
-
-    let position: Option<Vec<Position>> = api.get_position(1217, &driver_number, Some(1));
-    println!("Position: {:?}", position);
-    let race_control: Option<Vec<RaceControl>> = api.get_race_control(
-        Some(Category::Flag),
-        Some(Flag::BlackAndWhite),
-        Some(driver_number),
-        Some("2023-01-01".to_string()),
-        Some("2023-09-01".to_string()),
-    );
-    println!("RaceControl: {:?}", race_control);
-
-    let stints: Option<Vec<Stint>> = api.get_stints(9165, Some(3));
-    println!("Stint: {:?}", stints);
-
-    let team_radio: Option<Vec<TeamRadio>> = api.get_team_radio(9158, Some(driver_number));
-    println!("TeamRadio: {:?}", team_radio);
-
-    let weather: Option<Vec<Weather>> = api.get_weather(1208, Some(130), Some(52));
-    println!("Weather: {:?}", weather);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,9 +51,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .expect("Session not found, or request timed out");
 
     let driver_number = get_driver_number(&DriverName::LandoNorris);
-    let _ = event_sync
-        .car_data_sync(session.session_key, Some(driver_number), Some(50))
-        .await;
+    // let _ = event_sync
+    //     .car_data_sync(session.session_key, Some(driver_number), Some(50))
+    //     .await;
     //let _ = event_sync.intervals_sync(session.session_key, None).await;
     // let _ = event_sync
     //     .team_radio_sync(session.session_key, Some(driver_number))
@@ -61,6 +61,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // let _ = event_sync
     //     .laps_sync(session.session_key, &driver_number, 1)
     //     .await;
+    let _ = event_sync.pit_sync(session.session_key, None).await;
     Ok(())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,9 +51,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .expect("Session not found, or request timed out");
 
     let driver_number = get_driver_number(&DriverName::LandoNorris);
-    // let _ = event_sync
-    //     .car_data_sync(session.session_key, Some(driver_number), Some(50))
-    //     .await;
+    let _ = event_sync
+        .car_data_sync(session.session_key, Some(driver_number), Some(50))
+        .await;
     //let _ = event_sync.intervals_sync(session.session_key, None).await;
     // let _ = event_sync
     //     .team_radio_sync(session.session_key, Some(driver_number))

--- a/src/types/Interval.rs
+++ b/src/types/Interval.rs
@@ -12,7 +12,7 @@
 */
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, PartialEq, Clone, Debug)]
 pub struct Interval {
     pub gap_to_leader: Option<f32>,
     pub interval: Option<f32>,

--- a/src/types/Lap.rs
+++ b/src/types/Lap.rs
@@ -47,17 +47,17 @@
 */
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, PartialEq, Clone, Debug)]
 pub struct Lap {
     pub date_start: String, //TODO: convert to timestamp
     pub driver_number: u32,
-    pub duration_sector_1: f32,
-    pub duration_sector_2: f32,
-    pub duration_sector_3: f32,
+    pub duration_sector_1: Option<f32>,
+    pub duration_sector_2: Option<f32>,
+    pub duration_sector_3: Option<f32>,
     pub i1_speed: u32,
     pub i2_speed: u32,
     pub is_pit_out_lap: bool,
-    pub lap_duration: f32,
+    pub lap_duration: Option<f32>,
     pub lap_number: u32,
     pub meeting_key: u32,
     // Dropping these because they'll throw in a null in the array sometimes

--- a/src/types/Pit.rs
+++ b/src/types/Pit.rs
@@ -10,12 +10,12 @@
 */
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, PartialEq, Clone, Debug)]
 pub struct Pit {
     pub date: String, //TODO: convert to timestamp
     pub driver_number: u32,
     pub lap_number: u32,
     pub meeting_key: u32,
-    pub pit_duration: f32,
+    pub pit_duration: Option<f32>,
     pub session_key: u32,
 }

--- a/src/types/Position.rs
+++ b/src/types/Position.rs
@@ -9,7 +9,7 @@
 */
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, PartialEq, Clone, Debug)]
 pub struct Position {
     pub date: String, //TODO: convert to timestamp
     pub driver_number: u32,

--- a/src/types/Stint.rs
+++ b/src/types/Stint.rs
@@ -12,7 +12,7 @@
 */
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, PartialEq, Clone, Debug)]
 pub struct Stint {
     pub compound: String,
     pub driver_number: u32,

--- a/src/types/event_sync.rs
+++ b/src/types/event_sync.rs
@@ -1,0 +1,9 @@
+pub struct EventSyncConfig {
+    pub car_data_duration_secs: u64,
+    pub interval_duration_secs: u64,
+    pub team_radio_duration_secs: u64,
+    pub laps_duration_secs: u64,
+    pub pit_duration_secs: u64,
+    pub position_duration_secs: u64,
+    pub stints_duration_secs: u64,
+}

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,6 +1,7 @@
 pub mod car_data;
 pub mod car_location;
 pub mod driver;
+pub mod event_sync;
 pub mod flag;
 pub mod interval;
 pub mod lap;

--- a/src/types/team_radio.rs
+++ b/src/types/team_radio.rs
@@ -9,7 +9,7 @@
  */
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, PartialEq, Debug)]
+#[derive(Serialize, Clone, Deserialize, PartialEq, Debug)]
 pub struct TeamRadio {
     pub date: String, //TODO: replace with timestamp
     pub driver_number: u32,


### PR DESCRIPTION
# add redis sync methods to EventSync algebra

## syncs will be included for the following data:
- [x] car_data
- [x] intervals
- [x] team_radio
- [x] laps
- [x] pit
- [x] position
- [x] stints
- [x] run_sync
