### PR TITLE
add cache prefetch to websocket connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,6 @@ Currently a work in progress using the [openf1.org](https://openf1.org/) to aggr
 
 Note: more endponts might be required to make metadata available for filtering
 the above endpoints.
+
+## [API data source](https://openf1.org/?shell#introduction)
+

--- a/README.md
+++ b/README.md
@@ -30,7 +30,10 @@ Currently a work in progress using the [openf1.org](https://openf1.org/) to aggr
   - [X] pit
   - [X] position
   - [X] stints
-- [ ] websocket data pre-fetch
+- [X] websocket data pre-fetch
+- [ ] cache data for each driver for:
+  - [ ] car_data
+  - [ ] position
 
 Note: more endponts might be required to make metadata available for filtering
 the above endpoints.

--- a/src/algebras/channel_queue.rs
+++ b/src/algebras/channel_queue.rs
@@ -1,6 +1,7 @@
 use crate::types::event::*;
 use log::error;
 use std::clone::Clone;
+use std::fmt;
 use tokio::sync::broadcast::error::SendError;
 use tokio::sync::broadcast::*;
 
@@ -17,6 +18,12 @@ pub trait ChannelQueue: Send + Sync {
 #[derive(Clone, Debug)]
 pub struct Message {
     pub msg: Event,
+}
+
+impl fmt::Display for Message {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self.msg)
+    }
 }
 
 pub struct ChannelQueueImpl {

--- a/src/algebras/event_sync.rs
+++ b/src/algebras/event_sync.rs
@@ -14,9 +14,7 @@ use crate::types::position::Position;
 use crate::types::stint::Stint;
 use crate::types::team_radio::TeamRadio;
 use async_trait::async_trait;
-use log::{debug, error, info};
 use std::sync::Arc;
-use tokio::sync::broadcast::Sender;
 use tokio::time::{self, Duration};
 
 #[async_trait]
@@ -61,7 +59,6 @@ pub struct EventSyncImpl<'a> {
 
 #[async_trait]
 impl EventSync for EventSyncImpl<'_> {
-    //TODO: clean this up once we're finished
     async fn car_data_sync(
         &self,
         session_key: u32,

--- a/src/algebras/event_sync.rs
+++ b/src/algebras/event_sync.rs
@@ -203,17 +203,17 @@ impl EventSync for EventSyncImpl<'_> {
     ) {
         tokio_scoped::scope(|scope| {
             scope.spawn(async move {
-                tokio::select! {
-                        _ = self.car_data_sync(session_key, Some(driver_number), speed) => {},
-                        _ = self.intervals_sync(session_key, maybe_interval) => {},
-                // We want to sync all team radio, not by driver
-                        _ = self.team_radio_sync(session_key, None) => {},
-                //TODO: Research required: lap could cause issues, depending on value provided.
-                        _ = self.laps_sync(session_key, &driver_number, lap) => {},
-                        _ = self.pit_sync(session_key, pit_duration) => {},
-                        _ = self.position_sync(meeting_key, &driver_number, position) => {},
-                        _ = self.stints_sync(session_key, tyre_age) => {},
-                    }
+                tokio::join!(
+                    self.car_data_sync(session_key, Some(driver_number), speed),
+                    self.intervals_sync(session_key, maybe_interval),
+                    // We want to sync all team radio, not by driver
+                    self.team_radio_sync(session_key, None),
+                    //TODO: Research required: lap could cause issues, depending on value provided.
+                    self.laps_sync(session_key, &driver_number, lap),
+                    self.pit_sync(session_key, pit_duration),
+                    self.position_sync(meeting_key, &driver_number, position),
+                    self.stints_sync(session_key, tyre_age),
+                );
             });
         });
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,6 @@ use crate::algebras::redis::RedisImpl;
 use crate::algebras::websocket::Websocket;
 use crate::algebras::websocket::WebsocketImpl;
 use crate::types::driver::*;
-use crate::types::event::Event;
 use crate::types::event_sync::EventSyncConfig;
 use crate::types::session::Session;
 use std::error::Error;
@@ -19,7 +18,6 @@ use std::thread;
 use std::time::Duration;
 use tokio::sync::broadcast;
 use tracing::info;
-use tracing_subscriber::FmtSubscriber;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
@@ -81,8 +79,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
     thread::sleep(Duration::from_millis(5000));
 
     info!("Begin Websocket streaming");
-    // TODO: is this for logging or tracing too?
-    tracing::subscriber::set_global_default(FmtSubscriber::default())?;
     let _ = Arc::new(WebsocketImpl {
         redis_client: Arc::new(redis_client.clone()),
         channel_tx: channel_queue,

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,11 +49,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let event_sync_delay_config: &'static EventSyncConfig = &EventSyncConfig {
         car_data_duration_secs: 2,
         interval_duration_secs: 5,
-        team_radio_duration_secs: 5, //30
-        laps_duration_secs: 5,       //120
-        pit_duration_secs: 5,        //120
-        position_duration_secs: 5,   //TODO: probably higher if we're not using this...
-        stints_duration_secs: 5,     //120
+        team_radio_duration_secs: 30,
+        laps_duration_secs: 120,
+        pit_duration_secs: 120,
+        position_duration_secs: 120,
+        stints_duration_secs: 120,
     };
     let event_sync = EventSyncImpl {
         api: &api,

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,11 +49,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let event_sync_delay_config: &'static EventSyncConfig = &EventSyncConfig {
         car_data_duration_secs: 2,
         interval_duration_secs: 5,
-        team_radio_duration_secs: 30,
-        laps_duration_secs: 120,
-        pit_duration_secs: 120,
-        position_duration_secs: 5, //TODO: probably higher if we're not using this...
-        stints_duration_secs: 120,
+        team_radio_duration_secs: 5, //30
+        laps_duration_secs: 5,       //120
+        pit_duration_secs: 5,        //120
+        position_duration_secs: 5,   //TODO: probably higher if we're not using this...
+        stints_duration_secs: 5,     //120
     };
     let event_sync = EventSyncImpl {
         api: &api,
@@ -85,8 +85,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
     tracing::subscriber::set_global_default(FmtSubscriber::default())?;
     let _ = Arc::new(WebsocketImpl {
         redis_client: Arc::new(redis_client.clone()),
+        channel_tx: channel_queue,
     })
-    .run(channel_queue)
+    .run()
     .await;
 
     Ok(())

--- a/src/types/Event.rs
+++ b/src/types/Event.rs
@@ -11,3 +11,18 @@ pub enum Event {
     Stint,
     TeamRadio,
 }
+
+impl Event {
+    pub fn all_variants() -> Vec<Event> {
+        vec![
+            Event::CarData,
+            Event::Interval,
+            Event::Lap,
+            Event::Pit,
+            Event::Position,
+            Event::Session,
+            Event::Stint,
+            Event::TeamRadio,
+        ]
+    }
+}

--- a/src/types/to_json.rs
+++ b/src/types/to_json.rs
@@ -1,5 +1,3 @@
-use serde_json;
-
 pub trait ToJson {
     fn to_json(&self) -> Option<String>;
 }


### PR DESCRIPTION
want to prefetch all cache data and send it to client to prevent client from waiting the duration required for another data fetch to be performed. 