### PR TITLE
replace lifetimes with Arc

### DIFF
--- a/LIFETIMES_AND_ARC_REFACTOR.md
+++ b/LIFETIMES_AND_ARC_REFACTOR.md
@@ -1,0 +1,173 @@
+# Lifetimes, Static Lifetimes, and the Arc Refactor
+
+This document explains the previous implementation using `Box::leak()` and static lifetimes, why it was necessary, and how the `Arc`-based solution solves the same problem more elegantly.
+
+## The Previous Implementation
+
+The original code used `Box::leak()` to create `'static` references to services:
+
+```rust
+let uri: &'static str = Box::leak(Box::new(String::from("https://api.openf1.org"))).as_str();
+let http_requester: &'static TelemetryHttpRequester = &TelemetryHttpRequester;
+let api: &'static CarDataApiImpl = Box::leak(Box::new(CarDataApiImpl {
+    http_requester: &http_requester,
+    uri: &uri,
+}));
+```
+
+Structs were defined with lifetime parameters:
+
+```rust
+pub struct CarDataApiImpl<'a> {
+    pub http_requester: &'a TelemetryHttpRequester,
+    pub uri: &'a str,
+}
+
+pub struct EventSyncImpl<'a> {
+    pub api: &'a CarDataApiImpl<'a>,
+    pub redis: &'a RedisImpl,
+    pub delay_config: &'a EventSyncConfig,
+    pub tx: Arc<dyn ChannelQueue>,
+}
+```
+
+## Why Lifetimes Were Required
+
+Rust's ownership system requires that all references have a known lifetime - a guarantee about how long the referenced data will remain valid. When you have structs that hold references to other data, Rust needs to track these relationships to prevent use-after-free bugs.
+
+In our case:
+- `CarDataApiImpl` needed to hold a reference to `TelemetryHttpRequester` and a URI string
+- `EventSyncImpl` needed to hold references to `CarDataApiImpl`, `RedisImpl`, and `EventSyncConfig`
+
+Without lifetime parameters, Rust couldn't verify that these references would remain valid for as long as the structs using them. The lifetime parameter `<'a>` tells Rust: "this struct's references are valid for at least as long as lifetime `'a`."
+
+## Why Static Lifetimes Specifically?
+
+You might wonder: why not just use regular lifetimes like `<'a>` instead of `'static`?
+
+### The Problem with Regular Lifetimes
+
+When you have nested structures with references, lifetime constraints become complex:
+
+```rust
+pub struct CarDataApiImpl<'a> {
+    pub http_requester: &'a TelemetryHttpRequester,
+    pub uri: &'a str,
+}
+
+pub struct EventSyncImpl<'a> {
+    pub api: &'a CarDataApiImpl<'a>,  // This creates a constraint
+    pub redis: &'a RedisImpl,
+    // ...
+}
+```
+
+The constraint `&'a CarDataApiImpl<'a>` means: "I'm borrowing a `CarDataApiImpl` that itself has lifetime `'a`, and I'm borrowing it for lifetime `'a`." This creates a requirement that all the lifetimes must align perfectly.
+
+### The Async Problem
+
+The real issue emerges when you try to use these structs in async contexts:
+
+```rust
+tokio::spawn(async move {
+    let _ = event_sync.run_sync(...).await;
+});
+```
+
+When you move a struct with lifetime parameters into an async task, Rust needs to ensure that:
+1. The struct outlives the async task
+2. All the references within the struct outlive the async task
+3. The nested lifetime relationships are maintained
+
+This becomes extremely difficult (often impossible) to express with regular lifetimes because:
+- The async task might outlive the scope where the struct was created
+- The borrow checker can't verify that references will remain valid across await points
+- Nested lifetime constraints create complex dependency chains
+
+### The Static Lifetime Workaround
+
+`'static` means "valid for the entire program duration." By using `Box::leak()` to create `'static` references:
+
+1. **Bypasses lifetime checking**: `'static` references are considered valid forever, so Rust doesn't need to track their lifetimes
+2. **Works with async**: Since `'static` references are valid forever, they can be safely moved into async tasks
+3. **Simplifies nested structures**: No need to carefully align lifetime parameters across nested structs
+
+However, this comes at a cost:
+- **Memory leak**: `Box::leak()` prevents the memory from ever being freed
+- **Hides the actual ownership model**: The code doesn't express what's really happening
+- **Makes testing harder**: Can't easily create new instances for testing
+
+## How Arc Solves the Same Problem
+
+The `Arc` (Atomically Reference Counted) solution eliminates the need for lifetimes entirely by changing from **borrowing** to **shared ownership**.
+
+### The Key Difference
+
+**Before (Borrowing):**
+```rust
+pub struct CarDataApiImpl<'a> {
+    pub http_requester: &'a TelemetryHttpRequester,  // Borrowing
+    pub uri: &'a str,                                  // Borrowing
+}
+```
+
+**After (Ownership):**
+```rust
+pub struct CarDataApiImpl {
+    pub http_requester: Arc<TelemetryHttpRequester>,  // Shared ownership
+    pub uri: Arc<String>,                              // Shared ownership
+}
+```
+
+### Why This Works
+
+1. **No lifetimes needed**: When you own the data (via `Arc`), there are no references to track. `Arc` manages the lifetime internally through reference counting.
+
+2. **Works with async**: `Arc` is `Send + Sync`, meaning it can be safely shared across thread boundaries and moved into async tasks. The reference counting ensures the data lives as long as any `Arc` pointing to it exists.
+
+3. **Automatic cleanup**: When the last `Arc` is dropped, the data is automatically freed. No memory leaks.
+
+4. **Simpler code**: No lifetime parameters to manage, no complex lifetime constraints to satisfy.
+
+### How Arc Works
+
+`Arc` provides shared ownership through reference counting:
+- Multiple `Arc` instances can point to the same data
+- Each `Arc` increments a reference count
+- When an `Arc` is dropped, the count decrements
+- When the count reaches zero, the data is freed
+- The counting is atomic (thread-safe), so it works across threads and async tasks
+
+### Example: Sharing Services
+
+```rust
+// Create services with Arc
+let http_requester = Arc::new(TelemetryHttpRequester);
+let api = Arc::new(CarDataApiImpl {
+    http_requester: http_requester.clone(),  // Clone the Arc, not the data
+    uri: uri.clone(),
+});
+
+// Can be safely moved into async tasks
+tokio::spawn(async move {
+    // api is moved here, but the data it points to is shared
+    // When this task ends, the Arc is dropped, but the data
+    // remains as long as other Arcs point to it
+    api.get_session(...);
+});
+```
+
+## Summary
+
+| Aspect | Previous (Static Lifetimes) | Current (Arc) |
+|--------|------------------------------|---------------|
+| **Ownership Model** | Borrowing with `'static` references | Shared ownership with `Arc` |
+| **Memory Management** | Leaked (never freed) | Automatic (freed when last `Arc` drops) |
+| **Lifetime Parameters** | Required (but bypassed with `'static`) | Not needed |
+| **Async Compatibility** | Works (but hacky) | Works (idiomatic) |
+| **Thread Safety** | Depends on data | Guaranteed (`Arc` is `Send + Sync`) |
+| **Testability** | Difficult (static references) | Easy (can create new instances) |
+| **Code Complexity** | High (lifetime annotations) | Low (no lifetimes) |
+
+The `Arc` solution is the idiomatic Rust way to handle shared ownership across async boundaries, providing the same functionality as the static lifetime approach but with proper memory management and cleaner code.
+

--- a/src/algebras/car_data_api.rs
+++ b/src/algebras/car_data_api.rs
@@ -15,6 +15,7 @@ use crate::types::stint::Stint;
 use crate::types::team_radio::TeamRadio;
 use crate::types::weather::Weather;
 use log::debug;
+use std::sync::Arc;
 use std::vec::Vec;
 
 pub trait CarDataApi {
@@ -72,19 +73,19 @@ pub trait CarDataApi {
     ) -> Option<Vec<Weather>>;
 }
 
-pub struct CarDataApiImpl<'a> {
-    pub http_requester: &'a TelemetryHttpRequester,
-    pub uri: &'a str,
+pub struct CarDataApiImpl {
+    pub http_requester: Arc<TelemetryHttpRequester>,
+    pub uri: Arc<String>,
 }
 
-impl CarDataApi for CarDataApiImpl<'_> {
+impl CarDataApi for CarDataApiImpl {
     fn get_session(
         &self,
         country_name: &str,
         session_name: &str,
         year: u32,
     ) -> Option<Vec<Session>> {
-        let request_url = self.uri.to_owned()
+        let request_url = self.uri.as_str().to_owned()
             + &format!(
                 "/v1/sessions?country_name={country_name}&session_name={session_name}&year={year}"
             );
@@ -97,7 +98,7 @@ impl CarDataApi for CarDataApiImpl<'_> {
     }
 
     fn get_drivers(&self, session_key: u32, driver_number: &DriverNumber) -> Option<Vec<Driver>> {
-        let request_url = self.uri.to_owned()
+        let request_url = self.uri.as_str().to_owned()
             + &format!(
                 "/v1/drivers?driver_number={}&session_key={}",
                 driver_number, session_key
@@ -119,7 +120,7 @@ impl CarDataApi for CarDataApiImpl<'_> {
         let driver_num_str =
             driver_number.map_or_else(|| "".to_string(), |dr| format!("&driver_number={}", dr));
         let speed = speed.map_or_else(|| "".to_string(), |s| format!("&speed>={}", s));
-        let request_url = self.uri.to_owned()
+        let request_url = self.uri.as_str().to_owned()
             + &format!(
                 "/v1/car_data?session_key={}{}{}",
                 session_key, driver_num_str, speed
@@ -139,7 +140,7 @@ impl CarDataApi for CarDataApiImpl<'_> {
     ) -> Option<Vec<Interval>> {
         let interval_query_param =
             maybe_interval.map_or_else(|| "".to_string(), |i| format!("&interval<{}", i));
-        let request_url = self.uri.to_owned()
+        let request_url = self.uri.as_str().to_owned()
             + &format!(
                 "/v1/intervals?session_key={}{}",
                 session_key, interval_query_param
@@ -158,7 +159,7 @@ impl CarDataApi for CarDataApiImpl<'_> {
         driver_number: &DriverNumber,
         lap: u32,
     ) -> Option<Vec<Lap>> {
-        let request_url = self.uri.to_owned()
+        let request_url = self.uri.as_str().to_owned()
             + &format!(
                 "/v1/laps?session_key={}&driver_number={}&lap_number={}",
                 session_key, driver_number, lap
@@ -178,7 +179,7 @@ impl CarDataApi for CarDataApiImpl<'_> {
         start_time: &str,
         end_time: &str,
     ) -> Option<Vec<CarLocation>> {
-        let request_url = self.uri.to_owned()
+        let request_url = self.uri.as_str().to_owned()
             + &format!(
                 "/v1/location?session_key={}&driver_number={}&date>{}&date<{}",
                 session_key, driver_number, start_time, end_time
@@ -193,7 +194,7 @@ impl CarDataApi for CarDataApiImpl<'_> {
 
     fn get_meeting(&self, year: u32, country: &str) -> Option<Vec<Meeting>> {
         let request_url =
-            self.uri.to_owned() + &format!("/v1/meetings?year={}&country_name={}", year, country);
+            self.uri.as_str().to_owned() + &format!("/v1/meetings?year={}&country_name={}", year, country);
         debug!("{:?}", request_url);
         match self.http_requester.get::<Vec<Meeting>>(&request_url) {
             Ok(meeting) if meeting.is_empty() => None,
@@ -205,7 +206,7 @@ impl CarDataApi for CarDataApiImpl<'_> {
     fn get_pit(&self, session_key: u32, pit_duration: Option<u32>) -> Option<Vec<Pit>> {
         let pit_duration_str =
             pit_duration.map_or_else(|| "".to_string(), |p| format!("&pit_duration<{}", &p));
-        let request_url = self.uri.to_owned()
+        let request_url = self.uri.as_str().to_owned()
             + &format!("/v1/pit?session_key={}{}", session_key, pit_duration_str);
         debug!("{:?}", request_url);
         match self.http_requester.get::<Vec<Pit>>(&request_url) {
@@ -222,7 +223,7 @@ impl CarDataApi for CarDataApiImpl<'_> {
         position: Option<u32>,
     ) -> Option<Vec<Position>> {
         let position_str = position.map_or_else(|| "".to_string(), |p| format!("&position<={}", p));
-        let request_url = self.uri.to_owned()
+        let request_url = self.uri.as_str().to_owned()
             + &format!(
                 "/v1/position?meeting_key={}&driver_number={}{}",
                 meeting_key, driver_number, position_str
@@ -244,7 +245,7 @@ impl CarDataApi for CarDataApiImpl<'_> {
         end_date: Option<String>,
     ) -> Option<Vec<RaceControl>> {
         let params = build_query_params(category, flag, driver_number, start_date, end_date);
-        let request_url = self.uri.to_owned() + &"/v1/race_control" + &params;
+        let request_url = self.uri.as_str().to_owned() + &"/v1/race_control" + &params;
         debug!("{:?}", request_url);
         match self.http_requester.get::<Vec<RaceControl>>(&request_url) {
             Ok(race_control) if race_control.is_empty() => None,
@@ -256,7 +257,7 @@ impl CarDataApi for CarDataApiImpl<'_> {
     fn get_stints(&self, session_key: u32, tyre_age: Option<u32>) -> Option<Vec<Stint>> {
         let tyre_age_at_start =
             tyre_age.map_or_else(|| "".to_string(), |t| format!("&tyre_age_at_start>={}", &t));
-        let request_url = self.uri.to_owned()
+        let request_url = self.uri.as_str().to_owned()
             + &format!(
                 "/v1/stints?session_key={}{}",
                 session_key, tyre_age_at_start
@@ -276,7 +277,7 @@ impl CarDataApi for CarDataApiImpl<'_> {
     ) -> Option<Vec<TeamRadio>> {
         let driver_num_str =
             driver_number.map_or_else(|| "".to_string(), |dn| format!("&driver_number={}", &dn));
-        let request_url = self.uri.to_owned()
+        let request_url = self.uri.as_str().to_owned()
             + &format!(
                 "/v1/team_radio?session_key={}{}",
                 session_key, driver_num_str
@@ -301,7 +302,7 @@ impl CarDataApi for CarDataApiImpl<'_> {
             || "".to_string(),
             |tt| format!("&track_temperature>={}", &tt),
         );
-        let request_url = self.uri.to_owned()
+        let request_url = self.uri.as_str().to_owned()
             + &format!(
                 "/v1/weather?meeting_key={}{}{}",
                 meeting_key, wind_direction_str, track_temp_str

--- a/src/algebras/event_sync.rs
+++ b/src/algebras/event_sync.rs
@@ -52,15 +52,15 @@ pub trait EventSync {
     );
 }
 
-pub struct EventSyncImpl<'a> {
-    pub api: &'a CarDataApiImpl<'a>,
-    pub redis: &'a RedisImpl,
-    pub delay_config: &'a EventSyncConfig,
+pub struct EventSyncImpl {
+    pub api: Arc<CarDataApiImpl>,
+    pub redis: Arc<RedisImpl>,
+    pub delay_config: Arc<EventSyncConfig>,
     pub tx: Arc<dyn ChannelQueue>,
 }
 
 #[async_trait]
-impl EventSync for EventSyncImpl<'_> {
+impl EventSync for EventSyncImpl {
     async fn car_data_upsert(
         &self,
         session_key: u32,

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,12 +22,12 @@ use tracing::info;
 async fn main() -> Result<(), Box<dyn Error>> {
     env_logger::init();
 
-    let uri: &'static str = Box::leak(Box::new(String::from("https://api.openf1.org"))).as_str();
-    let http_requester: &'static TelemetryHttpRequester = &TelemetryHttpRequester;
-    let api: &'static CarDataApiImpl = Box::leak(Box::new(CarDataApiImpl {
-        http_requester: &http_requester,
-        uri: &uri,
-    }));
+    let uri = Arc::new(String::from("https://api.openf1.org"));
+    let http_requester = Arc::new(TelemetryHttpRequester);
+    let api = Arc::new(CarDataApiImpl {
+        http_requester: http_requester.clone(),
+        uri: uri.clone(),
+    });
 
     let sessions: Option<Vec<Session>> =
         api.get_session(&"Italy".to_string(), &"Qualifying".to_string(), 2024);
@@ -36,13 +36,13 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .and_then(|vec| vec.clone().pop())
         .expect("Session not found, or request timed out");
 
-    let redis_client: &'static RedisImpl = Box::leak(Box::new(
+    let redis_client = Arc::new(
         RedisImpl::default().expect("unable to connect to redis"),
-    ));
+    );
     let (channel_tx, _) = broadcast::channel::<Message>(100);
     let channel_queue = Arc::new(ChannelQueueImpl { tx: channel_tx });
 
-    let event_sync_delay_config: &'static EventSyncConfig = &EventSyncConfig {
+    let event_sync_delay_config = Arc::new(EventSyncConfig {
         car_data_duration_secs: 2,
         interval_duration_secs: 5,
         team_radio_duration_secs: 30,
@@ -50,11 +50,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
         pit_duration_secs: 120,
         position_duration_secs: 120,
         stints_duration_secs: 120,
-    };
+    });
     let event_sync = EventSyncImpl {
-        api: &api,
-        redis: &redis_client,
-        delay_config: &event_sync_delay_config,
+        api: api.clone(),
+        redis: redis_client.clone(),
+        delay_config: event_sync_delay_config.clone(),
         tx: channel_queue.clone(),
     };
 
@@ -76,7 +76,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     info!("Begin Websocket streaming");
     let _ = Arc::new(WebsocketImpl {
-        redis_client: Arc::new(redis_client.clone()),
+        redis_client: redis_client.clone(),
         channel_tx: channel_queue,
     })
     .run()


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switch services and configs to Arc-based ownership (removing lifetimes/Box::leak) across `CarDataApiImpl`, `EventSyncImpl`, and `main`, plus add documentation on the refactor.
> 
> - **Core refactor**:
>   - Convert `CarDataApiImpl` to use `Arc<TelemetryHttpRequester>` and `Arc<String>`; remove lifetimes and update impl accordingly.
>   - Convert `EventSyncImpl` to hold `Arc<CarDataApiImpl>`, `Arc<RedisImpl>`, and `Arc<EventSyncConfig>`; update trait impl to match.
>   - Update `src/main.rs` to construct services/configs as `Arc`, clone where needed, and remove `Box::leak()`/`'static` references.
> - **Request URL building**: switch to `self.uri.as_str().to_owned()` throughout API methods.
> - **Docs**: add `LIFETIMES_AND_ARC_REFACTOR.md` explaining the move from lifetimes/`Box::leak()` to `Arc`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0223fe0a155d0817d8b287b443a8c9b2d4ed9d2a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->