### PR TITLE
replace lifetimes & box with clones

### DIFF
--- a/OWNED_VALUES_COMPARISON.md
+++ b/OWNED_VALUES_COMPARISON.md
@@ -1,0 +1,265 @@
+# Owned Values Implementation: Tradeoffs and Comparison
+
+This document explains the owned values implementation, its tradeoffs, and compares it to both the static lifetimes with `Box::leak()` approach and the `Arc`-based implementation.
+
+## Implementation Overview
+
+The owned values approach uses Rust's ownership system directly, with each struct owning its dependencies rather than borrowing or sharing them via `Arc`.
+
+### Key Changes
+
+1. **Struct Definitions**: Removed lifetime parameters, use owned types
+2. **Clone Implementation**: All service types implement `Clone` to enable sharing
+3. **Main Function**: Services are cloned when needed for multiple consumers
+
+### Code Structure
+
+```rust
+// Structs own their dependencies
+pub struct CarDataApiImpl {
+    pub http_requester: TelemetryHttpRequester,  // Owned
+    pub uri: String,                              // Owned
+}
+
+pub struct EventSyncImpl {
+    pub api: CarDataApiImpl,                      // Owned
+    pub redis: RedisImpl,                         // Owned
+    pub delay_config: EventSyncConfig,           // Owned
+    pub tx: Arc<dyn ChannelQueue>,                // Still Arc (needs sharing)
+}
+
+// In main.rs - clone when sharing
+let api = CarDataApiImpl { ... };
+let event_sync = EventSyncImpl {
+    api: api.clone(),  // Clone for EventSyncImpl
+    // ...
+};
+// api is still available here for other uses
+```
+
+## Tradeoffs of Owned Values
+
+### Advantages
+
+1. **No Lifetime Parameters**: Cleaner code without `<'a>` annotations
+2. **Clear Ownership**: Each struct owns its dependencies, making ownership flow explicit
+3. **No Reference Counting Overhead**: No atomic operations for `Arc`
+4. **Simpler Mental Model**: Easier to reason about for developers new to Rust
+5. **Better for Single-Threaded Code**: No need for `Arc` if not sharing across threads
+6. **No Memory Leaks**: Proper cleanup when values are dropped
+
+### Disadvantages
+
+1. **Cloning Overhead**: Services must be cloned when shared:
+   - `TelemetryHttpRequester`: Zero-sized, essentially free
+   - `String` (URI): ~25 bytes, small allocation
+   - `EventSyncConfig`: 56 bytes, stack copy
+   - `RedisImpl`: **Expensive** - clones connection pool and state
+   - `CarDataApiImpl`: Clones all fields (including `String`)
+
+2. **Ownership Constraints**: Cannot use the same instance in multiple places without cloning:
+   ```rust
+   let api = CarDataApiImpl { ... };
+   let event_sync = EventSyncImpl { api };  // api moved
+   api.get_session(...);  // ERROR: api was moved
+   ```
+
+3. **Memory Usage**: Each clone creates a new instance:
+   - Multiple `RedisImpl` instances = multiple connection pools
+   - Multiple `String` copies = multiple heap allocations
+
+4. **May Not Work for All Types**: If a type cannot be cloned (e.g., some connection types), this approach won't work
+
+## Comparison: Three Approaches
+
+### 1. Static Lifetimes with `Box::leak()`
+
+**Implementation:**
+```rust
+let uri: &'static str = Box::leak(Box::new(String::from("..."))).as_str();
+let api: &'static CarDataApiImpl = Box::leak(Box::new(CarDataApiImpl {
+    http_requester: &http_requester,
+    uri: &uri,
+}));
+```
+
+**Characteristics:**
+- ✅ No lifetime parameters needed
+- ✅ Works with async
+- ❌ **Memory leak** - data never freed
+- ❌ Hides actual ownership model
+- ❌ Difficult to test (static references)
+- ❌ Not idiomatic Rust
+
+**Performance:**
+- No cloning overhead
+- No reference counting overhead
+- Memory never freed (leak)
+
+### 2. Arc-Based Implementation
+
+**Implementation:**
+```rust
+let uri = Arc::new(String::from("..."));
+let api = Arc::new(CarDataApiImpl {
+    http_requester: http_requester.clone(),
+    uri: uri.clone(),
+});
+```
+
+**Characteristics:**
+- ✅ No lifetime parameters needed
+- ✅ Works with async
+- ✅ Automatic memory management
+- ✅ Thread-safe sharing
+- ✅ Idiomatic Rust
+- ⚠️ Atomic reference counting overhead (~20 cycles per clone/drop)
+- ⚠️ 16 bytes overhead per `Arc`
+
+**Performance:**
+- No data cloning (just reference counting)
+- Atomic operations for reference counting
+- Memory freed when last `Arc` drops
+
+### 3. Owned Values (Current Implementation)
+
+**Implementation:**
+```rust
+let uri = String::from("...");
+let api = CarDataApiImpl {
+    http_requester: http_requester.clone(),
+    uri: uri.clone(),
+};
+```
+
+**Characteristics:**
+- ✅ No lifetime parameters needed
+- ✅ Clear ownership model
+- ✅ No reference counting overhead
+- ✅ Works with async (by moving/cloning)
+- ⚠️ Cloning overhead for shared services
+- ⚠️ Multiple allocations for cloned services
+
+**Performance:**
+- Full data cloning when sharing
+- No atomic operations
+- Memory freed when each instance drops
+
+## Detailed Performance Comparison
+
+### Scenario: Sharing `RedisImpl` between `EventSyncImpl` and `WebsocketImpl`
+
+#### Static Lifetimes (`Box::leak`)
+```rust
+let redis: &'static RedisImpl = Box::leak(Box::new(RedisImpl::default()));
+// Cost: 1 allocation, never freed
+// Sharing: Free (just reference)
+```
+
+#### Arc Implementation
+```rust
+let redis = Arc::new(RedisImpl::default());  // 1 allocation
+let event_sync_redis = redis.clone();        // Atomic increment (~20 cycles)
+let websocket_redis = redis.clone();         // Atomic increment (~20 cycles)
+// Cost: 1 allocation + 2 atomic ops + 16 bytes overhead
+// Sharing: Very cheap (just reference counting)
+```
+
+#### Owned Values
+```rust
+let redis = RedisImpl::default();            // 1 allocation
+let event_sync_redis = redis.clone();        // Full clone (expensive!)
+let websocket_redis = redis.clone();         // Another full clone (expensive!)
+// Cost: 3 allocations (connection pools duplicated!)
+// Sharing: Expensive (full data copy)
+```
+
+### Performance Breakdown by Type
+
+| Type | Static Lifetimes | Arc | Owned Values |
+|------|------------------|-----|--------------|
+| **TelemetryHttpRequester** | 0 bytes, leak | 16 bytes overhead | 0 bytes, free clone |
+| **String (URI)** | ~25 bytes, leak | 16 bytes + data | ~25 bytes per clone |
+| **EventSyncConfig** | 56 bytes, leak | 16 bytes + data | 56 bytes per clone |
+| **RedisImpl** | 1 instance, leak | 1 instance + ref counting | Multiple instances |
+| **CarDataApiImpl** | 1 instance, leak | 1 instance + ref counting | Multiple instances |
+
+## When to Use Each Approach
+
+### Use Static Lifetimes (`Box::leak`) When:
+- ❌ **Never** - This is an anti-pattern
+- Only acceptable for prototyping or when you truly need data for the entire program lifetime
+
+### Use Arc When:
+- ✅ Services are expensive to clone (`RedisImpl`, connection pools)
+- ✅ Services are shared across many async tasks
+- ✅ You need thread-safe sharing
+- ✅ You want idiomatic Rust
+- ✅ Memory efficiency is important (avoid duplicating large structures)
+
+### Use Owned Values When:
+- ✅ Services are cheap to clone (zero-sized, small structs)
+- ✅ Services are used sequentially (not shared)
+- ✅ Single-threaded code (no need for `Arc`)
+- ✅ You want the simplest ownership model
+- ✅ Cloning overhead is acceptable
+
+## Real-World Analysis for This Codebase
+
+### Current Dependencies:
+
+1. **TelemetryHttpRequester**: Zero-sized struct
+   - **Owned Values**: Free to clone ✅
+   - **Arc**: 16 bytes overhead ❌
+
+2. **String (URI)**: ~25 bytes
+   - **Owned Values**: Small clone cost ⚠️
+   - **Arc**: Small overhead, but better if shared ✅
+
+3. **EventSyncConfig**: 56 bytes (7 u64s)
+   - **Owned Values**: Small clone cost ⚠️
+   - **Arc**: Small overhead, but better if shared ✅
+
+4. **RedisImpl**: Contains connection pool
+   - **Owned Values**: **Very expensive** to clone ❌
+   - **Arc**: Cheap sharing ✅
+
+5. **CarDataApiImpl**: Contains `TelemetryHttpRequester` + `String`
+   - **Owned Values**: Moderate clone cost ⚠️
+   - **Arc**: Better if shared ✅
+
+### Recommendation for This Codebase
+
+**Arc is the better choice** because:
+
+1. **RedisImpl is expensive to clone**: Cloning connection pools is wasteful
+2. **Services are shared**: `api` is used in both `main` and `EventSyncImpl`, `redis_client` is used in both `EventSyncImpl` and `WebsocketImpl`
+3. **Async context**: Services are moved into async tasks, where `Arc` shines
+4. **Memory efficiency**: One `RedisImpl` instance vs multiple cloned instances
+
+**Owned Values would be better if:**
+- Services were not shared (each component gets its own instance)
+- Services were very cheap to clone
+- You wanted the simplest possible ownership model
+
+## Conclusion
+
+The owned values implementation is a valid approach that:
+- ✅ Eliminates lifetime parameters
+- ✅ Provides clear ownership semantics
+- ✅ Avoids memory leaks
+- ⚠️ Requires cloning when sharing services
+- ⚠️ Can be expensive for large/complex services
+
+**For this specific codebase, `Arc` is the better choice** due to:
+1. The expensive nature of cloning `RedisImpl`
+2. The need to share services across async tasks
+3. Better memory efficiency
+
+However, owned values are a good fit when:
+- Services are cheap to clone
+- Services are not shared extensively
+- You want the simplest ownership model
+
+The static lifetimes approach should be avoided entirely as it's an anti-pattern that causes memory leaks and hides the actual ownership model.
+

--- a/src/algebras/car_data_api.rs
+++ b/src/algebras/car_data_api.rs
@@ -72,19 +72,20 @@ pub trait CarDataApi {
     ) -> Option<Vec<Weather>>;
 }
 
-pub struct CarDataApiImpl<'a> {
-    pub http_requester: &'a TelemetryHttpRequester,
-    pub uri: &'a str,
+#[derive(Clone)]
+pub struct CarDataApiImpl {
+    pub http_requester: TelemetryHttpRequester,
+    pub uri: String,
 }
 
-impl CarDataApi for CarDataApiImpl<'_> {
+impl CarDataApi for CarDataApiImpl {
     fn get_session(
         &self,
         country_name: &str,
         session_name: &str,
         year: u32,
     ) -> Option<Vec<Session>> {
-        let request_url = self.uri.to_owned()
+        let request_url = self.uri.clone()
             + &format!(
                 "/v1/sessions?country_name={country_name}&session_name={session_name}&year={year}"
             );
@@ -97,7 +98,7 @@ impl CarDataApi for CarDataApiImpl<'_> {
     }
 
     fn get_drivers(&self, session_key: u32, driver_number: &DriverNumber) -> Option<Vec<Driver>> {
-        let request_url = self.uri.to_owned()
+        let request_url = self.uri.clone()
             + &format!(
                 "/v1/drivers?driver_number={}&session_key={}",
                 driver_number, session_key
@@ -119,7 +120,7 @@ impl CarDataApi for CarDataApiImpl<'_> {
         let driver_num_str =
             driver_number.map_or_else(|| "".to_string(), |dr| format!("&driver_number={}", dr));
         let speed = speed.map_or_else(|| "".to_string(), |s| format!("&speed>={}", s));
-        let request_url = self.uri.to_owned()
+        let request_url = self.uri.clone()
             + &format!(
                 "/v1/car_data?session_key={}{}{}",
                 session_key, driver_num_str, speed
@@ -139,7 +140,7 @@ impl CarDataApi for CarDataApiImpl<'_> {
     ) -> Option<Vec<Interval>> {
         let interval_query_param =
             maybe_interval.map_or_else(|| "".to_string(), |i| format!("&interval<{}", i));
-        let request_url = self.uri.to_owned()
+        let request_url = self.uri.clone()
             + &format!(
                 "/v1/intervals?session_key={}{}",
                 session_key, interval_query_param
@@ -158,7 +159,7 @@ impl CarDataApi for CarDataApiImpl<'_> {
         driver_number: &DriverNumber,
         lap: u32,
     ) -> Option<Vec<Lap>> {
-        let request_url = self.uri.to_owned()
+        let request_url = self.uri.clone()
             + &format!(
                 "/v1/laps?session_key={}&driver_number={}&lap_number={}",
                 session_key, driver_number, lap
@@ -178,7 +179,7 @@ impl CarDataApi for CarDataApiImpl<'_> {
         start_time: &str,
         end_time: &str,
     ) -> Option<Vec<CarLocation>> {
-        let request_url = self.uri.to_owned()
+        let request_url = self.uri.clone()
             + &format!(
                 "/v1/location?session_key={}&driver_number={}&date>{}&date<{}",
                 session_key, driver_number, start_time, end_time
@@ -193,7 +194,7 @@ impl CarDataApi for CarDataApiImpl<'_> {
 
     fn get_meeting(&self, year: u32, country: &str) -> Option<Vec<Meeting>> {
         let request_url =
-            self.uri.to_owned() + &format!("/v1/meetings?year={}&country_name={}", year, country);
+            self.uri.clone() + &format!("/v1/meetings?year={}&country_name={}", year, country);
         debug!("{:?}", request_url);
         match self.http_requester.get::<Vec<Meeting>>(&request_url) {
             Ok(meeting) if meeting.is_empty() => None,
@@ -205,7 +206,7 @@ impl CarDataApi for CarDataApiImpl<'_> {
     fn get_pit(&self, session_key: u32, pit_duration: Option<u32>) -> Option<Vec<Pit>> {
         let pit_duration_str =
             pit_duration.map_or_else(|| "".to_string(), |p| format!("&pit_duration<{}", &p));
-        let request_url = self.uri.to_owned()
+        let request_url = self.uri.clone()
             + &format!("/v1/pit?session_key={}{}", session_key, pit_duration_str);
         debug!("{:?}", request_url);
         match self.http_requester.get::<Vec<Pit>>(&request_url) {
@@ -222,7 +223,7 @@ impl CarDataApi for CarDataApiImpl<'_> {
         position: Option<u32>,
     ) -> Option<Vec<Position>> {
         let position_str = position.map_or_else(|| "".to_string(), |p| format!("&position<={}", p));
-        let request_url = self.uri.to_owned()
+        let request_url = self.uri.clone()
             + &format!(
                 "/v1/position?meeting_key={}&driver_number={}{}",
                 meeting_key, driver_number, position_str
@@ -244,7 +245,7 @@ impl CarDataApi for CarDataApiImpl<'_> {
         end_date: Option<String>,
     ) -> Option<Vec<RaceControl>> {
         let params = build_query_params(category, flag, driver_number, start_date, end_date);
-        let request_url = self.uri.to_owned() + &"/v1/race_control" + &params;
+        let request_url = self.uri.clone() + &"/v1/race_control" + &params;
         debug!("{:?}", request_url);
         match self.http_requester.get::<Vec<RaceControl>>(&request_url) {
             Ok(race_control) if race_control.is_empty() => None,
@@ -256,7 +257,7 @@ impl CarDataApi for CarDataApiImpl<'_> {
     fn get_stints(&self, session_key: u32, tyre_age: Option<u32>) -> Option<Vec<Stint>> {
         let tyre_age_at_start =
             tyre_age.map_or_else(|| "".to_string(), |t| format!("&tyre_age_at_start>={}", &t));
-        let request_url = self.uri.to_owned()
+        let request_url = self.uri.clone()
             + &format!(
                 "/v1/stints?session_key={}{}",
                 session_key, tyre_age_at_start
@@ -276,7 +277,7 @@ impl CarDataApi for CarDataApiImpl<'_> {
     ) -> Option<Vec<TeamRadio>> {
         let driver_num_str =
             driver_number.map_or_else(|| "".to_string(), |dn| format!("&driver_number={}", &dn));
-        let request_url = self.uri.to_owned()
+        let request_url = self.uri.clone()
             + &format!(
                 "/v1/team_radio?session_key={}{}",
                 session_key, driver_num_str
@@ -301,7 +302,7 @@ impl CarDataApi for CarDataApiImpl<'_> {
             || "".to_string(),
             |tt| format!("&track_temperature>={}", &tt),
         );
-        let request_url = self.uri.to_owned()
+        let request_url = self.uri.clone()
             + &format!(
                 "/v1/weather?meeting_key={}{}{}",
                 meeting_key, wind_direction_str, track_temp_str

--- a/src/algebras/event_sync.rs
+++ b/src/algebras/event_sync.rs
@@ -52,15 +52,16 @@ pub trait EventSync {
     );
 }
 
-pub struct EventSyncImpl<'a> {
-    pub api: &'a CarDataApiImpl<'a>,
-    pub redis: &'a RedisImpl,
-    pub delay_config: &'a EventSyncConfig,
+#[derive(Clone)]
+pub struct EventSyncImpl {
+    pub api: CarDataApiImpl,
+    pub redis: RedisImpl,
+    pub delay_config: EventSyncConfig,
     pub tx: Arc<dyn ChannelQueue>,
 }
 
 #[async_trait]
-impl EventSync for EventSyncImpl<'_> {
+impl EventSync for EventSyncImpl {
     async fn car_data_upsert(
         &self,
         session_key: u32,

--- a/src/algebras/http_requester.rs
+++ b/src/algebras/http_requester.rs
@@ -9,6 +9,7 @@ pub trait HttpRequester {
     fn get<T: DeserializeOwned>(&self, url: &str) -> Result<T, Box<dyn Error>>;
 }
 
+#[derive(Clone)]
 pub struct TelemetryHttpRequester;
 impl HttpRequester for TelemetryHttpRequester {
     fn get<T: DeserializeOwned>(&self, url: &str) -> Result<T, Box<dyn Error>> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,12 +22,12 @@ use tracing::info;
 async fn main() -> Result<(), Box<dyn Error>> {
     env_logger::init();
 
-    let uri: &'static str = Box::leak(Box::new(String::from("https://api.openf1.org"))).as_str();
-    let http_requester: &'static TelemetryHttpRequester = &TelemetryHttpRequester;
-    let api: &'static CarDataApiImpl = Box::leak(Box::new(CarDataApiImpl {
-        http_requester: &http_requester,
-        uri: &uri,
-    }));
+    let uri = String::from("https://api.openf1.org");
+    let http_requester = TelemetryHttpRequester;
+    let api = CarDataApiImpl {
+        http_requester: http_requester.clone(),
+        uri: uri.clone(),
+    };
 
     let sessions: Option<Vec<Session>> =
         api.get_session(&"Italy".to_string(), &"Qualifying".to_string(), 2024);
@@ -36,13 +36,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .and_then(|vec| vec.clone().pop())
         .expect("Session not found, or request timed out");
 
-    let redis_client: &'static RedisImpl = Box::leak(Box::new(
-        RedisImpl::default().expect("unable to connect to redis"),
-    ));
+    let redis_client = RedisImpl::default().expect("unable to connect to redis");
     let (channel_tx, _) = broadcast::channel::<Message>(100);
     let channel_queue = Arc::new(ChannelQueueImpl { tx: channel_tx });
 
-    let event_sync_delay_config: &'static EventSyncConfig = &EventSyncConfig {
+    let event_sync_delay_config = EventSyncConfig {
         car_data_duration_secs: 2,
         interval_duration_secs: 5,
         team_radio_duration_secs: 30,
@@ -52,9 +50,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
         stints_duration_secs: 120,
     };
     let event_sync = EventSyncImpl {
-        api: &api,
-        redis: &redis_client,
-        delay_config: &event_sync_delay_config,
+        api: api.clone(),
+        redis: redis_client.clone(),
+        delay_config: event_sync_delay_config.clone(),
         tx: channel_queue.clone(),
     };
 

--- a/src/types/event_sync.rs
+++ b/src/types/event_sync.rs
@@ -1,3 +1,4 @@
+#[derive(Clone)]
 pub struct EventSyncConfig {
     pub car_data_duration_secs: u64,
     pub interval_duration_secs: u64,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switches from lifetime-bound leaked statics to owned, Clone-based services and updates wiring; adds a doc comparing owned vs Arc vs Box::leak approaches.
> 
> - **Core refactor (owned values + Clone)**:
>   - `CarDataApiImpl`: remove lifetimes; now owns `TelemetryHttpRequester` and `String uri`; `#[derive(Clone)]`; update URL building to use `self.uri.clone()`; impl updated to `impl CarDataApi for CarDataApiImpl`.
>   - `EventSyncImpl`: remove lifetimes; now owns `CarDataApiImpl`, `RedisImpl`, and `EventSyncConfig`; `#[derive(Clone)]`; trait impl updated.
>   - `TelemetryHttpRequester`: `#[derive(Clone)]`.
>   - `EventSyncConfig`: `#[derive(Clone)]`.
> - **Main wiring** (`src/main.rs`):
>   - Remove `Box::leak()` lifetimes; instantiate owned `String` URI, `TelemetryHttpRequester`, `CarDataApiImpl`, and `RedisImpl`.
>   - Clone services when sharing into `EventSyncImpl` and websocket setup.
> - **Docs**:
>   - Add `OWNED_VALUES_COMPARISON.md` detailing tradeoffs vs `Arc` and `Box::leak()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4df8f73ff0880d8f87fe28dde3297957b2e42b42. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->